### PR TITLE
Fix Developer: Plugin Setup lightbox options save if filesystem is not 'direct'

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -164,7 +164,6 @@ class Automattic_Developer {
 
 		register_setting( self::OPTION, self::OPTION, array( $this, 'settings_validate' ) );
 
-
 		wp_register_script( 'a8c-developer', plugins_url( 'developer.js', __FILE__ ), array( 'jquery' ), self::VERSION );
 		$strings = array(
 			'settings_slug'  => self::PAGE_SLUG,
@@ -184,14 +183,10 @@ class Automattic_Developer {
 
 		wp_register_style( 'a8c-developer', plugins_url( 'developer.css', __FILE__ ), array(), self::VERSION );
 
-
 		// Handle the submission of the lightbox form if step 2 won't be shown
-		if ( ! empty( $_POST['a8c_developer_action'] ) ) {
-			if ( 'lightbox_step_1' == $_POST['a8c_developer_action'] && ! empty( $_POST['a8c_developer_project_type'] ) && check_admin_referer( 'a8c_developer_action_lightbox_step_1' ) ) {
-				$this->save_project_type( $_POST['a8c_developer_project_type'] );
-
-				add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'updated' );
-			}
+		if ( ! empty( $_POST['action'] ) && 'a8c_developer_lightbox_step_1' == $_POST['action'] && ! empty( $_POST['a8c_developer_project_type'] ) && check_admin_referer( 'a8c_developer_lightbox_step_1' ) ) {
+			$this->save_project_type( $_POST['a8c_developer_project_type'] );
+			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'updated' );
 		}
 
 		if ( ! get_option( self::OPTION ) ) {


### PR DESCRIPTION
In the case that the filesystem type is detected as non-"direct," the
options from the lightbox when first installing the plugin are
attempted to be saved on the next page load. However, some of the
conditional checks here had incorrect $_POST variable name checks, as
well as the check_admin_referer string. So if you were in this
situation, you get the lightbox popping up repeatedly on every page
load on the admin, until you decide to fix the issue and send a pull
request.
