### PR TITLE
fix calls to get_error_message()

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -164,7 +164,6 @@ class Automattic_Developer {
 
 		register_setting( self::OPTION, self::OPTION, array( $this, 'settings_validate' ) );
 
-
 		wp_register_script( 'a8c-developer', plugins_url( 'developer.js', __FILE__ ), array( 'jquery' ), self::VERSION );
 		$strings = array(
 			'settings_slug'  => self::PAGE_SLUG,
@@ -184,14 +183,10 @@ class Automattic_Developer {
 
 		wp_register_style( 'a8c-developer', plugins_url( 'developer.css', __FILE__ ), array(), self::VERSION );
 
-
 		// Handle the submission of the lightbox form if step 2 won't be shown
-		if ( ! empty( $_POST['a8c_developer_action'] ) ) {
-			if ( 'lightbox_step_1' == $_POST['a8c_developer_action'] && ! empty( $_POST['a8c_developer_project_type'] ) && check_admin_referer( 'a8c_developer_action_lightbox_step_1' ) ) {
-				$this->save_project_type( $_POST['a8c_developer_project_type'] );
-
-				add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'updated' );
-			}
+		if ( ! empty( $_POST['action'] ) && 'a8c_developer_lightbox_step_1' == $_POST['action'] && ! empty( $_POST['a8c_developer_project_type'] ) && check_admin_referer( 'a8c_developer_lightbox_step_1' ) ) {
+			$this->save_project_type( $_POST['a8c_developer_project_type'] );
+			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'updated' );
 		}
 
 		if ( ! get_option( self::OPTION ) ) {
@@ -249,7 +244,7 @@ class Automattic_Developer {
 
 				<p><?php esc_html_e( 'Before we begin, what type of website are you developing?', 'a8c-developer' ); ?></p>
 
-				<form id="a8c-developer-setup-dialog-step-1-form" action="options-general.php?page=a8c_developer" method="post">
+				<form id="a8c-developer-setup-dialog-step-1-form" action="tools.php?page=a8c_developer" method="post">
 					<?php wp_nonce_field( 'a8c_developer_lightbox_step_1' ); ?>
 					<input type="hidden" name="action" value="a8c_developer_lightbox_step_1" />
 


### PR DESCRIPTION
When trying to install a couple of the recommended plugins I was receiving 503 errors on the ajax request.

The fix is to call $failed_request->get_error_message() instead of get_error_message( $failed_request ) since $failed_request is an instance of WP_Error.

For reference, my debug log had these two entries:

PHP Fatal error:  Call to undefined function get_error_message() in /path-to-wp-content/plugins/developer/developer.php on line 347
PHP Fatal error:  Call to undefined function get_error_message() in /path-to-wp-content/plugins/developer/developer.php on line 363
