### PR TITLE
Fix error reporting and Theme Test Drive activation

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -160,6 +160,7 @@ class Automattic_Developer {
 				'project_type' => 'wporg-theme',
 				'name'         => esc_html__( 'Theme Test Drive', 'a8c-developer' ),
 				'active'       => function_exists( 'TTD_filters' ),
+				'filename'     => 'themedrive.php',
 			),
 			'theme-check' => array(
 				'project_type' => 'wporg-theme',
@@ -350,7 +351,7 @@ class Automattic_Developer {
 				$api = plugins_api( 'plugin_information', array( 'slug' => $_POST['plugin_slug'], 'fields' => array( 'sections' => false ) ) );
 
 				if ( is_wp_error( $api ) )
-					die( sprintf( __( 'ERROR: Error fetching plugin information: %s', 'a8c-developer' ), $api->get_error_message( $api ) ) );
+					die( sprintf( __( 'ERROR: Error fetching plugin information: %s', 'a8c-developer' ), $api->get_error_message() ) );
 
 				$upgrader = new Plugin_Upgrader( new Automattic_Developer_Empty_Upgrader_Skin( array(
 					'nonce'  => 'install-plugin_' . $_POST['plugin_slug'],
@@ -361,12 +362,12 @@ class Automattic_Developer {
 				$install_result = $upgrader->install( $api->download_link );
 
 				if ( ! $install_result || is_wp_error( $install_result ) )
-					die( sprintf( __( 'ERROR: Failed to install plugin: %s', 'a8c-developer' ), $install_result->get_error_message( $install_result ) ) );
+					die( sprintf( __( 'ERROR: Failed to install plugin: %s', 'a8c-developer' ), $install_result->get_error_message() ) );
 
 				$activate_result = activate_plugin( $this->get_path_for_recommended_plugin( $_POST['plugin_slug'] ) );
 
 				if ( is_wp_error( $activate_result ) )
-					die( sprintf( __( 'ERROR: Failed to activate plugin: %s', 'a8c-developer' ), $activate_result->get_error_message( $activate_result ) ) );
+					die( sprintf( __( 'ERROR: Failed to activate plugin: %s', 'a8c-developer' ), $activate_result->get_error_message() ) );
 
 				exit( '1' );
 
@@ -382,7 +383,7 @@ class Automattic_Developer {
 				$activate_result = activate_plugin( $_POST['path'] );
 
 				if ( is_wp_error( $activate_result ) )
-					die( sprintf( __( 'ERROR: Failed to activate plugin: %s', 'a8c-developer' ), $activate_result->get_error_message( $activate_result ) ) );
+					die( sprintf( __( 'ERROR: Failed to activate plugin: %s', 'a8c-developer' ), $activate_result->get_error_message() ) );
 
 				exit( '1' );
 		}


### PR DESCRIPTION
There's an error when installing Theme Test Drive:

```
<br />
<b>Warning</b>:  Illegal offset type in isset or empty in <b>wp-includes/class-wp-error.php</b> on line <b>117</b><br />
ERROR: Failed to activate plugin: 
```

This is caused by passing the WP_Error object itself as the error code:
http://plugins.trac.wordpress.org/browser/developer/tags/1.1.2/developer.php#L364

Once I replaced that with `$activate_result->get_error_message()`, I got the proper message:

```
ERROR: Failed to activate plugin: Plugin file does not exist.
```

The plugin looks for `theme-test-drive/theme-test-drive.php` file, which doesn't exist. The correct file is `theme-test-drive/themedrive.php`.

SergeyBiryukov/developer@750025709f85532998d9f3bb96dc820df4623c11 fixes both of these issues.
