### PR TITLE
Update README to reflect Debug Bar Console being added in 1.2.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,7 @@ Because you haven't asked one yet.
 
 = 1.2.1 (2013-06-18) =
 * Added MP6 to recommended plugins
+* Added Koop's Debug Bar Console to recommended plugins
 
 = 1.1.6 (2013-04-08) =
 * Made purpose of activate/install links on Settings page more obvious


### PR DESCRIPTION
Plugin was added with 1.2.1 but I didn't update the docs to reflect it. Updated here
