### PR TITLE
Bump 1.2.2

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -5,7 +5,7 @@
 Plugin Name:  Developer
 Plugin URI:   http://wordpress.org/extend/plugins/developer/
 Description:  The first stop for every WordPress developer
-Version:      1.2.1
+Version:      1.2.2
 Author:       Automattic
 Author URI:   http://automattic.com
 License:      GPLv2 or later
@@ -14,6 +14,7 @@ Text Domain:  a8c-developer
 Domain Path:  /languages/
 
 **************************************************************************/
+
 // Load helper class if installing a plugin
 if ( ! empty( $_POST['action'] ) && 'a8c_developer_install_plugin' == $_POST['action'] )
 	require_once( dirname( __FILE__ ) . '/includes/class-empty-upgrader-skin.php' );
@@ -24,7 +25,7 @@ class Automattic_Developer {
 	public $settings               = array();
 	public $default_settings       = array();
 
-	const VERSION                  = '1.1.6';
+	const VERSION                  = '1.2.2';
 	const OPTION                   = 'a8c_developer';
 	const PAGE_SLUG                = 'a8c_developer';
 

--- a/includes/class-wp-cli-commands.php
+++ b/includes/class-wp-cli-commands.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Developer Plugin commands for WP-CLI.
- * @since 1.2
+ * @since 1.2.2
  */
 class Developer_WP_CLI_Command extends WP_CLI_Command {
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, batmoo, Viper007Bond, nbachiyski, tott, danielbachhube
 Tags: developer, development, local
 Requires at least: 3.4
 Tested up to: 3.6
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,10 @@ Because you haven't asked one yet.
 4. The plugin's settings page (Tools > Developer) will check to make sure your environment is correctly configured, including plugins, constants, and other settings.
 
 == Changelog ==
+
+= 1.2.2 (2013-08-09) =
+* Added WP-CLI command
+* Removed Grunion Contact Form because it's part of Jetpack
 
 = 1.2.1 (2013-06-18) =
 * Added MP6 to recommended plugins


### PR DESCRIPTION
Sync with WordPress.org plugin repo. I probably could have just pushed to the Automattic repo for this.
