### PR TITLE
Fixed Strict Standard Errors

### DIFF
--- a/includes/class-empty-upgrader-skin.php
+++ b/includes/class-empty-upgrader-skin.php
@@ -13,15 +13,15 @@ class Automattic_Developer_Empty_Upgrader_Skin extends WP_Upgrader_Skin {
 		parent::__construct( $args );
 	}
 
-	public function request_filesystem_credentials() {
+	public function request_filesystem_credentials( $error = false ) {
 		return true;
 	}
 
-	public function error() {
+	public function error( $errors ) {
 		die( '-1' );
 	}
 
 	public function header() {}
 	public function footer() {}
-	public function feedback() {}
+	public function feedback( $string ) {}
 }


### PR DESCRIPTION
Fixed an issue with Strict standard Errors when trying to activate Beta Tester plugin under WP3.6. Screenshot attached:

![screen shot 2013-08-11 at 8 54 34 am](https://f.cloud.github.com/assets/1505631/943597/dfa1cbcc-0236-11e3-80ef-9acae26b8cda.png)
