### PR TITLE
Check for return type of get_preferred_from_update_core()

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -844,7 +844,7 @@ class Automattic_Developer {
 
 	private static function is_dev_version() {
 		$cur = get_preferred_from_update_core();
-		return $cur->response == 'development';
+		return ( isset( $cur->response ) && $cur->response == 'development' );
 	}
 
 	private static function is_project_type( $project, $type ) {


### PR DESCRIPTION
get_preferred_from_update_core() may return boolean false in which case trying to access its non-existent property would throw a notice.