### PR TITLE
Shouldn't assume result is an object. fixes #61

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -844,7 +844,7 @@ class Automattic_Developer {
 
 	private static function is_dev_version() {
 		$cur = get_preferred_from_update_core();
-		return $cur->response == 'development';
+		return isset( $cur->response ) && $cur->response == 'development';
 	}
 
 	private static function is_project_type( $project, $type ) {


### PR DESCRIPTION
Notice: Trying to get property of non-object in /srv/www/wp-content/plugins/developer/developer.php on line 847

Throws an error when get_preferred_from_update_core returns false. (new installs or provisions)
