### PR TITLE
Resolves Strict PHP Warning when checking unset object property

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -844,7 +844,12 @@ class Automattic_Developer {
 
 	private static function is_dev_version() {
 		$cur = get_preferred_from_update_core();
-		return $cur->response == 'development';
+
+		if( isset( $cur->response ) && 'development' == $cur->response ) {
+			return $cur->response;
+		}
+
+		return false;
 	}
 
 	private static function is_project_type( $project, $type ) {


### PR DESCRIPTION
Checks the the existence of the object property in Automattic_Developer::is_dev_version() in order to prevent strict PHP warning in PHP 5.4+
