### PR TITLE
Fixed request_filesystem_credentials() declaration

### DIFF
--- a/includes/class-empty-upgrader-skin.php
+++ b/includes/class-empty-upgrader-skin.php
@@ -13,7 +13,7 @@ class Automattic_Developer_Empty_Upgrader_Skin extends WP_Upgrader_Skin {
 		parent::__construct( $args );
 	}
 
-	public function request_filesystem_credentials( $error = false ) {
+	public function request_filesystem_credentials( $error = false, $context = false, $allow_relaxed_file_ownership = false ) {
 		return true;
 	}
 


### PR DESCRIPTION
Added the missing params in override of the request_filesystem_credentials() method. The new params were added in WP 4.1. This change is backward compatible since the additional params are optional and hence would continue to work with older versions of WP as well.