### PR TITLE
Properly detect status of Theme Check plugin

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -166,7 +166,7 @@ class Automattic_Developer {
 			'theme-check' => array(
 				'project_type' => 'wporg-theme',
 				'name'         => esc_html__( 'Theme Check', 'a8c-developer' ),
-				'active'       => function_exists( 'tc_add_headers' ),
+				'active'       => class_exists( 'ThemeCheckMain' ),
 			),
 		);
 


### PR DESCRIPTION
Theme Check versions 20140929.1 and higher use a class instead of
plain functions, so check for the existence of that class.

fixes #73